### PR TITLE
Add config provider for libvirt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,11 @@ Vagrant.configure("2") do |config|
     v.vmx["memsize"] = 2048
   end
 
+  config.vm.provider "libvirt" do |v|
+    v.cpus = 2
+    v.memory = 4096
+  end
+
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.


### PR DESCRIPTION
Libvirt is a virtualization library that leverages QEMU and KVM to
make running and managing virtual machines trivial.

* **Please check if the request fulfills these requirements**
- [x] The commit messages follow our guidelines (See [Contributing](https://github.com/HExSA-Lab/nautilus/blob/master/CONTRIBUTING.md)).
- [x] The code follows our style guidelines, again see Contributing.
- [ ] If this is a new feature, changes to the core kernel have been minimized.
- [ ] If this feature doesn't touch the core kernel, has it been properly separated out in the `Kconfig`? and the source tree?
- [ ] If this pull request is for an open issue, the issue is properly referenced.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Minor quality of life feature.


* **What is the current behavior?** (You can also link to an open issue here)
With Vagrant as the provisioner of the VM on `libvirt` Linux machines, the minimums are used, whichmakes development painfully slow.


* **What is the new behavior (if this is a feature change)?**
When creating Nautilus virtual machines with Vagrant on Linux systems using `libvirt`, the virtual machine now has 2 vCPUs and 4GiB of memory assigned to it.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
