### PR TITLE
fix riscv build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,10 @@ ARCH		?= $(SUBARCH)
 COMPILER_PREFIX := $(patsubst "%",%,$(NAUT_CONFIG_COMPILER_PREFIX))
 COMPILER_SUFFIX := $(patsubst "%",%,$(NAUT_CONFIG_COMPILER_SUFFIX))
 
+# RISCV HACK - currently needed to build for riscv
+ifdef NAUT_CONFIG_ARCH_RISCV
 COMPILER_PREFIX := riscv64-linux-gnu-
+endif
 
 #
 # Note we use the system linker in all cases

--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,7 @@ ARCH		?= $(SUBARCH)
 COMPILER_PREFIX := $(patsubst "%",%,$(NAUT_CONFIG_COMPILER_PREFIX))
 COMPILER_SUFFIX := $(patsubst "%",%,$(NAUT_CONFIG_COMPILER_SUFFIX))
 
+COMPILER_PREFIX := riscv64-linux-gnu-
 
 #
 # Note we use the system linker in all cases

--- a/include/dev/apic.h
+++ b/include/dev/apic.h
@@ -249,16 +249,24 @@ struct apic_dev {
 static inline void _apic_msr_write(uint32_t msr, 
 				   uint64_t data)
 {
+    // RISCV HACK
+    #ifdef NAUT_CONFIG_ARCH_X86
     uint32_t lo = data;
     uint32_t hi = data >> 32;
     __asm__ __volatile__ ("wrmsr" : : "c"(msr), "a"(lo), "d"(hi));
+    #endif
 }
 
 static inline uint64_t _apic_msr_read(uint32_t msr)
 {
+    // RISCV HACK
+    #ifdef NAUT_CONFIG_ARCH_X86
     uint32_t lo, hi;
     asm volatile("rdmsr" : "=a"(lo), "=d"(hi) : "c"(msr));
     return ((uint64_t)hi << 32) | lo;
+    #else
+    return 0;
+    #endif
 }
 
 static inline void

--- a/include/dev/sifive.h
+++ b/include/dev/sifive.h
@@ -13,9 +13,9 @@ struct sifive_serial_regs {
     volatile uint32_t div;
 };
 
-void serial_init(void);
-void serial_write(const char *b);
-void serial_putchar(unsigned char ch);
-int  serial_getchar(void);
+void sifive_serial_init(void);
+void sifive_serial_write(const char *b);
+void sifive_serial_putchar(unsigned char ch);
+int  sifive_serial_getchar(void);
 
 #endif

--- a/include/nautilus/cpuid.h
+++ b/include/nautilus/cpuid.h
@@ -289,13 +289,13 @@ typedef struct cpuid_ret {
 static int
 cpuid (uint32_t func, cpuid_ret_t * ret)
 {
-    asm volatile ("pushq %%rbx;"
-            "movq %%rdi, %%rbx;"
-            "cpuid ;"
-            "movq %%rbx, %%rdi; "
-            "popq %%rbx ;"
-            : "=a"(ret->a), "=D"(ret->b), "=c"(ret->c), "=d"(ret->d)
-            : "0"(func));
+    // asm volatile ("pushq %%rbx;"
+    //         "movq %%rdi, %%rbx;"
+    //         "cpuid ;"
+    //         "movq %%rbx, %%rdi; "
+    //         "popq %%rbx ;"
+    //         : "=a"(ret->a), "=D"(ret->b), "=c"(ret->c), "=d"(ret->d)
+    //         : "0"(func));
 
     return 0;
 }
@@ -304,13 +304,13 @@ cpuid (uint32_t func, cpuid_ret_t * ret)
 static int
 cpuid_sub (uint32_t func, uint32_t sub_func, cpuid_ret_t * ret)
 {
-    asm volatile ("pushq %%rbx;"
-            "movq %%rdi, %%rbx;"
-            "cpuid ;"
-            "movq %%rbx, %%rdi; "
-            "popq %%rbx ;"
-            : "=a"(ret->a), "=D"(ret->b), "=c"(ret->c), "=d"(ret->d)
-            : "0"(func), "2"(sub_func));
+    // asm volatile ("pushq %%rbx;"
+    //         "movq %%rdi, %%rbx;"
+    //         "cpuid ;"
+    //         "movq %%rbx, %%rdi; "
+    //         "popq %%rbx ;"
+    //         : "=a"(ret->a), "=D"(ret->b), "=c"(ret->c), "=d"(ret->d)
+    //         : "0"(func), "2"(sub_func));
 
     return 0;
 }

--- a/include/nautilus/cpuid.h
+++ b/include/nautilus/cpuid.h
@@ -289,13 +289,15 @@ typedef struct cpuid_ret {
 static int
 cpuid (uint32_t func, cpuid_ret_t * ret)
 {
-    // asm volatile ("pushq %%rbx;"
-    //         "movq %%rdi, %%rbx;"
-    //         "cpuid ;"
-    //         "movq %%rbx, %%rdi; "
-    //         "popq %%rbx ;"
-    //         : "=a"(ret->a), "=D"(ret->b), "=c"(ret->c), "=d"(ret->d)
-    //         : "0"(func));
+    #ifdef NAUT_CONFIG_ARCH_X86
+    asm volatile ("pushq %%rbx;"
+            "movq %%rdi, %%rbx;"
+            "cpuid ;"
+            "movq %%rbx, %%rdi; "
+            "popq %%rbx ;"
+            : "=a"(ret->a), "=D"(ret->b), "=c"(ret->c), "=d"(ret->d)
+            : "0"(func));
+    #endif
 
     return 0;
 }
@@ -304,13 +306,15 @@ cpuid (uint32_t func, cpuid_ret_t * ret)
 static int
 cpuid_sub (uint32_t func, uint32_t sub_func, cpuid_ret_t * ret)
 {
-    // asm volatile ("pushq %%rbx;"
-    //         "movq %%rdi, %%rbx;"
-    //         "cpuid ;"
-    //         "movq %%rbx, %%rdi; "
-    //         "popq %%rbx ;"
-    //         : "=a"(ret->a), "=D"(ret->b), "=c"(ret->c), "=d"(ret->d)
-    //         : "0"(func), "2"(sub_func));
+    #ifdef NAUT_CONFIG_ARCH_X86
+    asm volatile ("pushq %%rbx;"
+            "movq %%rdi, %%rbx;"
+            "cpuid ;"
+            "movq %%rbx, %%rdi; "
+            "popq %%rbx ;"
+            : "=a"(ret->a), "=D"(ret->b), "=c"(ret->c), "=d"(ret->d)
+            : "0"(func), "2"(sub_func));
+    #endif
 
     return 0;
 }

--- a/include/nautilus/irq.h
+++ b/include/nautilus/irq.h
@@ -34,7 +34,11 @@ extern "C" {
 
 extern void apic_do_eoi();
 
+#ifdef NAUT_CONFIG_ARCH_X86
 #define IRQ_HANDLER_END() apic_do_eoi()
+# else
+#define IRQ_HANDLER_END() 
+#endif
 
 typedef enum { INT_TYPE_INT, INT_TYPE_NMI, INT_TYPE_SMI, INT_TYPE_EXT } int_type_t;
 typedef enum { INT_POL_BUS, INT_POL_ACTHI, INT_POL_RSVD, INT_POL_ACTLO } int_pol_t;

--- a/include/nautilus/thread.h
+++ b/include/nautilus/thread.h
@@ -308,10 +308,13 @@ put_cur_thread (nk_thread_t * t)
 __attribute__((used))
 static inline nk_thread_t *get_cur_thread_fast(void)
 {
+    #ifdef NAUT_CONFIG_ARCH_X86
+    uint64_t thread;
+    asm("movq %%gs:0, %0" : "=a" (thread));    
+    return ((nk_thread_t *) thread);
+    #else
     return get_cur_thread();
-    // uint64_t thread;
-    // asm("movq %%gs:0, %0" : "=a" (thread));    
-    // return ((nk_thread_t *) thread);
+    #endif
 }
 
 

--- a/include/nautilus/thread.h
+++ b/include/nautilus/thread.h
@@ -308,9 +308,10 @@ put_cur_thread (nk_thread_t * t)
 __attribute__((used))
 static inline nk_thread_t *get_cur_thread_fast(void)
 {
-    uint64_t thread;
-    asm("movq %%gs:0, %0" : "=a" (thread));    
-    return ((nk_thread_t *) thread);
+    return get_cur_thread();
+    // uint64_t thread;
+    // asm("movq %%gs:0, %0" : "=a" (thread));    
+    // return ((nk_thread_t *) thread);
 }
 
 

--- a/include/nautilus/thread.h
+++ b/include/nautilus/thread.h
@@ -296,6 +296,7 @@ void nk_tls_test(void);
 static inline nk_thread_t*
 get_cur_thread (void)
 {
+    // RISCV HACK
     #ifdef NAUT_CONFIG_ARCH_X86
     return (nk_thread_t*)per_cpu_get(cur_thread);
     #else

--- a/include/nautilus/thread.h
+++ b/include/nautilus/thread.h
@@ -296,7 +296,11 @@ void nk_tls_test(void);
 static inline nk_thread_t*
 get_cur_thread (void)
 {
+    #ifdef NAUT_CONFIG_ARCH_X86
     return (nk_thread_t*)per_cpu_get(cur_thread);
+    #else
+    return (nk_thread_t*)0;
+    #endif
 }
 
 static inline void

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -231,6 +231,7 @@ cmd_as_s_S       = $(CPP) $(a_flags)   -o $@ $<
 
 quiet_cmd_as_o_S = AS $(quiet_modtag)  $@
 cmd_as_o_S       = $(CC) $(a_flags) -c -o $@ $<
+# cmd_as_o_S       = $(CC) $(a_flags) -mcmodel=medany -march=rv64gc -mabi=lp64d -c -o $@ $<
 
 %.o: %.S FORCE
 	$(call if_changed_dep,as_o_S)
@@ -262,7 +263,11 @@ cmd_link_o_target = $(if $(strip $(obj-y)),\
 		      $(LD) $(ld_flags) -r -o $@ $(filter $(obj-y), $^),\
 		      rm -f $@; $(AR) rcs $@)
 
-
+#
+# The builtin target depends on all targets obj-$(NAUT_CONFIG_...)
+# where the nautilus config var is set to "y", or the Makefile in the
+# target directly appends to obj-y
+#
 $(builtin-target): $(obj-y) FORCE
 	$(call if_changed,link_o_target)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,12 +7,13 @@ obj-$(NAUT_CONFIG_ARCH_X86) += \
 	rt/ \
 	net/ \
 	acpi/ \
-        compat/ \
+    compat/ \
 	test/ 
 
 obj-$(NAUT_CONFIG_ARCH_RISCV) += \
 	nautilus/ \
 	arch/ \
+	compat/ \
 	dev/
 
 obj-$(NAUT_CONFIG_CXX_SUPPORT) += cxx/

--- a/src/arch/riscv/Makefile
+++ b/src/arch/riscv/Makefile
@@ -9,4 +9,6 @@ obj-y += asm/ \
 	 trap.o \
 	 plic.o \
 	 monitor.o \
-	 paging.o
+	 paging.o \
+	 shutdown.o \
+	 irq.o

--- a/src/arch/riscv/arch.c
+++ b/src/arch/riscv/arch.c
@@ -108,10 +108,12 @@ void * arch_read_sp(void) {
 }
 
 void arch_relax(void) {
+    // RISCV HACK
     // asm volatile ("pause");
 }
 
 void arch_halt(void) {
+    // RISCV HACK
     // asm volatile ("hlt");
 }
 

--- a/src/arch/riscv/arch.c
+++ b/src/arch/riscv/arch.c
@@ -103,15 +103,15 @@ void arch_print_regs(struct nk_regs * r) {
 
 void * arch_read_sp(void) {
     void * sp = NULL;
-    __asm__ __volatile__ ( "mv %[_r], sp" : [_r] "=r" (rsp) : : "memory" );
+    __asm__ __volatile__ ( "mv %[_r], sp" : [_r] "=r" (sp) : : "memory" );
     return sp;
 }
 
 void arch_relax(void) {
-    asm volatile ("pause");
+    // asm volatile ("pause");
 }
 
 void arch_halt(void) {
-    asm volatile ("hlt");
+    // asm volatile ("hlt");
 }
 

--- a/src/arch/riscv/init.c
+++ b/src/arch/riscv/init.c
@@ -244,7 +244,7 @@ void init_full(unsigned long hartid, unsigned long fdt) {
   plic_init_hart(hartid);
 
   // We now have serial output without SBI
-  serial_init();
+  sifive_serial_init();
 
   sbi_init();
 
@@ -334,7 +334,7 @@ void init(unsigned long hartid, unsigned long fdt) {
   arch_enable_ints();
 
   // We now have serial output without SBI
-  serial_init();
+  sifive_serial_init();
 
   plic_dump();
 

--- a/src/arch/riscv/irq.c
+++ b/src/arch/riscv/irq.c
@@ -20,18 +20,12 @@
  * This is free software.  You are permitted to use,
  * redistribute, and modify it as specified in the file "LICENSE.txt".
  */
-#ifndef __SHUTDOWN_H__
-#define __SHUTDOWN_H__
+#include <nautilus/irq.h>
 
-
-void reboot(void) __attribute__((noreturn));;
-void acpi_shutdown(void) __attribute__((noreturn));
-void shutdown(void) __attribute__((noreturn));
-void qemu_shutdown(void) __attribute__((noreturn));
 // RISCV HACK
-#ifndef NAUT_CONFIG_ARCH_RISCV
-void qemu_shutdown_with_code(uint16_t code) __attribute__((noreturn));
-#endif
 
+void
+nk_unmask_irq (uint8_t irq)
+{
+}
 
-#endif

--- a/src/arch/riscv/monitor.c
+++ b/src/arch/riscv/monitor.c
@@ -111,8 +111,8 @@ int my_strcmp (const char * s1, const char * s2)
     }
 }
 
-#define DB(x) serial_putchar(x)
-#define DHN(x) serial_putchar(((x & 0xF) >= 10) ? (((x & 0xF) - 10) + 'a') : ((x & 0xF) + '0'))
+#define DB(x) sifive_serial_putchar(x)
+#define DHN(x) sifive_serial_putchar(((x & 0xF) >= 10) ? (((x & 0xF) - 10) + 'a') : ((x & 0xF) + '0'))
 #define DHB(x) DHN(x >> 4) ; DHN(x);
 #define DHW(x) DHB(x >> 8) ; DHB(x);
 #define DHL(x) DHW(x >> 16) ; DHW(x);
@@ -122,10 +122,10 @@ int my_strcmp (const char * s1, const char * s2)
 static void print(char *b)
 {
     while (b && *b) {
-        serial_putchar(*b);
+        sifive_serial_putchar(*b);
         b++;
     }
-    serial_putchar('\n');
+    sifive_serial_putchar('\n');
 }
 
 // Keyboard stuff repeats here to be self-contained
@@ -164,7 +164,7 @@ static void wait_for_command(char *buf, int buffer_size)
 
 		// continue;
 
-    /* key = serial_getchar(); */
+    /* key = sifive_serial_getchar(); */
     /* printk("%c", key); */
     // key = ps2_wait_for_key();
     // uint16_t key_encoded = kbd_translate_monitor(key);
@@ -695,7 +695,7 @@ static int nk_monitor_loop()
   while (!done) {
     DS("monitor> ");
     wait_for_command(buffer, buffer_size);
-    serial_putchar('\n');
+    sifive_serial_putchar('\n');
     done = execute_potential_command(buffer);
   };
   return 0;

--- a/src/arch/riscv/shutdown.c
+++ b/src/arch/riscv/shutdown.c
@@ -20,18 +20,17 @@
  * This is free software.  You are permitted to use,
  * redistribute, and modify it as specified in the file "LICENSE.txt".
  */
-#ifndef __SHUTDOWN_H__
-#define __SHUTDOWN_H__
+#include <nautilus/shutdown.h>
 
-
-void reboot(void) __attribute__((noreturn));;
-void acpi_shutdown(void) __attribute__((noreturn));
-void shutdown(void) __attribute__((noreturn));
-void qemu_shutdown(void) __attribute__((noreturn));
 // RISCV HACK
-#ifndef NAUT_CONFIG_ARCH_RISCV
-void qemu_shutdown_with_code(uint16_t code) __attribute__((noreturn));
-#endif
 
+void
+reboot (void)
+{
+}
 
-#endif
+/* TODO: fix this */
+void
+acpi_shutdown (void)
+{
+}

--- a/src/arch/riscv/smp.c
+++ b/src/arch/riscv/smp.c
@@ -119,16 +119,18 @@ out_ok:
     return 0;
 }
 
-/* Some fakery to get the scheduler working */
-uint8_t
-nk_topo_cpus_share_socket (struct cpu * a, struct cpu * b)
-{
-    return 1;
-    // return a->coord->pkg_id == b->coord->pkg_id;
-}
+// RISCV HACK
 
-uint8_t
-nk_topo_cpus_share_phys_core (struct cpu * a, struct cpu * b)
-{
-    return nk_topo_cpus_share_socket(a, b) && (a->coord->core_id == b->coord->core_id);
-}
+// /* Some fakery to get the scheduler working */
+// uint8_t
+// nk_topo_cpus_share_socket (struct cpu * a, struct cpu * b)
+// {
+//     return 1;
+//     // return a->coord->pkg_id == b->coord->pkg_id;
+// }
+
+// uint8_t
+// nk_topo_cpus_share_phys_core (struct cpu * a, struct cpu * b)
+// {
+//     return nk_topo_cpus_share_socket(a, b) && (a->coord->core_id == b->coord->core_id);
+// }

--- a/src/compat/libmcompat/math/sqrt/sqrt.c
+++ b/src/compat/libmcompat/math/sqrt/sqrt.c
@@ -11,6 +11,7 @@
 inline double sqrt(double x)
 {
     double ret;
+	#ifdef NAUT_CONFIG_ARCH_X86
     asm volatile(
 		 "movq %1, %%xmm0 \n"
 		 "sqrtsd %%xmm0, %%xmm1 \n"
@@ -19,6 +20,9 @@ inline double sqrt(double x)
 		 : "g"(x)
 		 : "xmm0", "xmm1", "memory"
 		 );
+	#else
+	ret = 0.0;
+	#endif
     return ret;
 }
 

--- a/src/dev/sifive.c
+++ b/src/dev/sifive.c
@@ -31,7 +31,9 @@ int sifive_test(void) {
     arch_enable_ints();
     while(1) {
         printk("ie=%p, ip=%p, sie=%p, status=%p, sip=%p, pp=%p\t\n", regs->ie, regs->ip, read_csr(sie), read_csr(sstatus), read_csr(sip), plic_pending());
+        printk("BEFORE WFI\n");
         asm volatile ("wfi");
+        printk("AFTER WFI\n");
         /* printk("%d\n", sifive_serial_getchar()); */
     }
 }

--- a/src/dev/sifive.c
+++ b/src/dev/sifive.c
@@ -23,7 +23,7 @@ int sifive_handler (excp_entry_t * excp, excp_vec_t vector, void *state) {
         if (r & UART_RXFIFO_EMPTY) break;
         char buf = r & 0xFF;
         // call virtual console here!
-        serial_putchar(buf);
+        sifive_serial_putchar(buf);
     }
 }
 
@@ -32,7 +32,7 @@ int sifive_test(void) {
     while(1) {
         printk("ie=%p, ip=%p, sie=%p, status=%p, sip=%p, pp=%p\t\n", regs->ie, regs->ip, read_csr(sie), read_csr(sstatus), read_csr(sip), plic_pending());
         asm volatile ("wfi");
-        /* printk("%d\n", serial_getchar()); */
+        /* printk("%d\n", sifive_serial_getchar()); */
     }
 }
 
@@ -67,24 +67,24 @@ bool_t dtb_node_get_sifive(struct dtb_node *n) {
     return true;
 }
 
-void serial_init(void) {
+void sifive_serial_init(void) {
     /* dtb_walk_devices(dtb_node_get_sifive); */
     /* regs = (struct sifive_serial_regs *)0x10010000L; */
     sifive_init(0x10010000L, 4);
 }
 
-void serial_write(const char *b) {
+void sifive_serial_write(const char *b) {
     while (b && *b) {
-        serial_putchar(*b);
+        sifive_serial_putchar(*b);
         b++;
     }
 }
 
-void serial_putchar(unsigned char ch) {
+void sifive_serial_putchar(unsigned char ch) {
     sbi_call(SBI_CONSOLE_PUTCHAR, ch);
 }
 
-int serial_getchar(void) {
+int sifive_serial_getchar(void) {
     if (!inited) {
         struct sbiret ret = sbi_call(SBI_CONSOLE_GETCHAR);
         return ret.error == -1 ? -1 : ret.value;

--- a/src/nautilus/Makefile
+++ b/src/nautilus/Makefile
@@ -32,8 +32,6 @@ obj-y += \
 	barrier.o \
 	backtrace.o \
 	cpu.o \
-	acpi.o \
-	numa.o \
 	env.o \
 	nemo.o \
 	pmc.o \

--- a/src/nautilus/cpu.c
+++ b/src/nautilus/cpu.c
@@ -222,7 +222,10 @@ ulong_t
 nk_detect_cpu_freq (uint32_t cpu) 
 {
     uint8_t flags = irq_disable_save();
-    ulong_t khz = i8254_calib_tsc();
+    ulong_t khz = ULONG_MAX;
+    #ifdef NAUT_CONFIG_ARCH_X86
+    khz = i8254_calib_tsc();
+    #endif
     if (khz == ULONG_MAX) {
         ERROR_PRINT("Unable to detect CPU frequency\n");
         goto out_err;
@@ -240,7 +243,9 @@ out_err:
 static int
 handle_regs (char * buf, void * priv)
 {
+    #ifdef NAUT_CONFIG_ARCH_X86
     extern int nk_interrupt_like_trampoline(void (*)(struct nk_regs *));
+    #endif
     uint64_t tid;
 
     if (sscanf(buf,"regs %lu",&tid) == 1) { 
@@ -253,7 +258,9 @@ handle_regs (char * buf, void * priv)
         return 0;
     }
 
+    #ifdef NAUT_CONFIG_ARCH_X86
     nk_interrupt_like_trampoline(nk_print_regs);
+    #endif
 
     return 0;
 }

--- a/src/nautilus/msr.c
+++ b/src/nautilus/msr.c
@@ -28,19 +28,26 @@
 inline void 
 msr_write (uint32_t msr, uint64_t data)
 {
-    // uint32_t lo = data;
-    // uint32_t hi = data >> 32;
-    // asm volatile("wrmsr" : : "c"(msr), "a"(lo), "d"(hi));
+    // RISCV HACK
+    #ifdef NAUT_CONFIG_ARCH_X86
+    uint32_t lo = data;
+    uint32_t hi = data >> 32;
+    asm volatile("wrmsr" : : "c"(msr), "a"(lo), "d"(hi));
+    #endif
 }
 
 
 inline uint64_t 
 msr_read (uint32_t msr) 
 {
-    // uint32_t lo, hi;
-    // asm volatile("rdmsr" : "=a"(lo), "=d"(hi) : "c"(msr));
-    // return ((uint64_t)hi << 32) | lo;
+    // RISCV HACK
+    #ifdef NAUT_CONFIG_ARCH_X86
+    uint32_t lo, hi;
+    asm volatile("rdmsr" : "=a"(lo), "=d"(hi) : "c"(msr));
+    return ((uint64_t)hi << 32) | lo;
+    #else
     return 0;
+    #endif
 }
 
 

--- a/src/nautilus/msr.c
+++ b/src/nautilus/msr.c
@@ -28,18 +28,19 @@
 inline void 
 msr_write (uint32_t msr, uint64_t data)
 {
-    uint32_t lo = data;
-    uint32_t hi = data >> 32;
-    asm volatile("wrmsr" : : "c"(msr), "a"(lo), "d"(hi));
+    // uint32_t lo = data;
+    // uint32_t hi = data >> 32;
+    // asm volatile("wrmsr" : : "c"(msr), "a"(lo), "d"(hi));
 }
 
 
 inline uint64_t 
 msr_read (uint32_t msr) 
 {
-    uint32_t lo, hi;
-    asm volatile("rdmsr" : "=a"(lo), "=d"(hi) : "c"(msr));
-    return ((uint64_t)hi << 32) | lo;
+    // uint32_t lo, hi;
+    // asm volatile("rdmsr" : "=a"(lo), "=d"(hi) : "c"(msr));
+    // return ((uint64_t)hi << 32) | lo;
+    return 0;
 }
 
 

--- a/src/nautilus/printk.c
+++ b/src/nautilus/printk.c
@@ -47,8 +47,8 @@
 #ifdef NAUT_CONFIG_ARCH_RISCV
 #include <dev/sifive.h>
 // All output is handled via UART
-#define do_putchar(x) do { serial_putchar(x); } while (0)
-#define do_puts(x)    do { serial_write(x); serial_putchar('\n'); } while (0)
+#define do_putchar(x) do { sifive_serial_putchar(x); } while (0)
+#define do_puts(x)    do { sifive_serial_write(x); sifive_serial_putchar('\n'); } while (0)
 #else
 // All output is handled via the virtual console
 #define do_putchar(x) do { nk_vc_putchar(x);} while (0)
@@ -57,7 +57,7 @@
 
 spinlock_t printk_lock;
 
-extern void serial_putchar(uchar_t c);
+extern void sifive_serial_putchar(uchar_t c);
 extern void serial_putln(const char * ln);
 
 struct printk_state {

--- a/src/nautilus/thread.c
+++ b/src/nautilus/thread.c
@@ -296,7 +296,7 @@ thread_setup_init_stack (nk_thread_t * t, nk_thread_fun_t fun, void * arg)
 static void nk_thread_brain_wipe(nk_thread_t *t);
 
 
-
+#ifdef NAUT_CONFIG_HARDWARE_TLS
 static int hwtls_config_kernel_tls(nk_thread_t *t)
 {
 
@@ -353,6 +353,7 @@ static int hwtls_config_kernel_tls(nk_thread_t *t)
     return 0;
 
 }
+#endif
 
 
 


### PR DESCRIPTION
riscv and x86 should both be building, x86 should still run fine

A few issues and hacky solutions here are:
- renaming to `sifive_serial` for the sifive driver may not be ideal
- `irq` and `shutdown` implementations added to riscv are empty
- Need to ensure riscv components are not relying on MSR (I think some are)
- Need to replace assembly code written for x86

- apic is getting used in the scheduler, which is not ideal since it is x86 only

Edit:

The kernel boots, you can see the halt location with:

```
qemu-system-riscv64 -m 2048 -bios default -kernel nautilus.bin -machine sifive_u -serial stdio
```