### PR TITLE
Improve ld handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,10 @@ ifdef NAUT_CONFIG_ARCH_RISCV
 ifdef NAUT_CONFIG_USE_GCC
 COMPILER_PREFIX := riscv64-linux-gnu-
 endif
+
+# wllvm needs this to use the correct version of objcopy
+# (see https://github.com/travitch/whole-program-llvm)
+export BINUTILS_TARGET_PREFIX=riscv64-linux-gnu
 endif
 
 #

--- a/Makefile
+++ b/Makefile
@@ -300,15 +300,6 @@ else
 endif
 
 
-# RISCV HACK - use ld.lld from dep/local/bin after running
-# ./scripts/build_deps.sh
-ifdef NAUT_CONFIG_USE_CLANG
-LDCMD = ld.lld
-else
-LDCMD = $(LD)
-endif
-
-
 AR		=     $(CROSS_COMPILE)$(COMPILER_PREFIX)ar
 NM		=     $(CROSS_COMPILE)$(COMPILER_PREFIX)nm
 STRIP		=   $(CROSS_COMPILE)$(COMPILER_PREFIX)strip
@@ -365,14 +356,14 @@ endif
 #
 ifdef NAUT_CONFIG_USE_CLANG
   AS		= $(CROSS_COMPILE)$(COMPILER_PREFIX)llvm-as$(COMPILER_SUFFIX)
-  LD		= $(CROSS_COMPILE)$(COMPILER_PREFIX)ld
+  LD		= $(CROSS_COMPILE)$(COMPILER_PREFIX)ld.lld
   CC		= $(CROSS_COMPILE)$(COMPILER_PREFIX)clang$(COMPILER_SUFFIX)
   CXX           = $(CROSS_COMPILE)$(COMPILER_PREFIX)clang++$(COMPILER_SUFFIX)
 endif
 
 ifdef NAUT_CONFIG_USE_WLLVM
   AS		= $(CROSS_COMPILE)$(COMPILER_PREFIX)llvm-as$(COMPILER_SUFFIX)
-  LD		= $(CROSS_COMPILE)$(COMPILER_PREFIX)ld
+  LD		= $(CROSS_COMPILE)$(COMPILER_PREFIX)ld.lld
   CC		= $(CROSS_COMPILE)$(COMPILER_PREFIX)wllvm$(COMPILER_SUFFIX)
   CXX           = $(CROSS_COMPILE)$(COMPILER_PREFIX)wllvm++$(COMPILER_SUFFIX)
 endif
@@ -794,8 +785,8 @@ quiet_cmd_transform_linkscript__ ?= CC      $@
 
 # Rule to link nautilus - also used during CONFIG_CONFIGKALLSYMS
 # May be overridden by /Makefile.$(ARCH)
-quiet_cmd_nautilus__ ?= $(LDCMD)      $@
-      cmd_nautilus__ ?= $(LDCMD) $(LDFLAGS) $(LDFLAGS_vmlinux) -o $@ \
+quiet_cmd_nautilus__ ?= $(LD)      $@
+      cmd_nautilus__ ?= $(LD) $(LDFLAGS) $(LDFLAGS_vmlinux) -o $@ \
       -T $(LD_SCRIPT) $(core-y)  \
       --start-group $(libs-y) --end-group
 
@@ -921,7 +912,7 @@ endif
 final: $(OPT_LL_NAME)
 	# Recompile (with full opt levels) new object files, binaries
 	clang $(CFLAGS) -c $(OPT_LL_NAME) -o .nautilus.o
-	$(LDCMD) $(LDFLAGS) $(LDFLAGS_vmlinux) -o $(BIN_NAME) -T $(LD_SCRIPT) .nautilus.o `scripts/findasm.pl`
+	$(LD) $(LDFLAGS) $(LDFLAGS_vmlinux) -o $(BIN_NAME) -T $(LD_SCRIPT) .nautilus.o `scripts/findasm.pl`
 	rm .nautilus.o
 
 strip: $(OPT_LL_NAME)
@@ -933,7 +924,7 @@ whole_opt: $(BIN_NAME) # FIX --- should be deprecated
 	extract-bc $(BIN_NAME) -o $(BC_NAME)
 	opt -strip-debug $(BC_NAME)
 	clang $(CFLAGS) -c $(BC_NAME) -o .nautilus.o
-	$(LDCMD) $(LDFLAGS) $(LDFLAGS_vmlinux) -o $(BIN_NAME) -T $(LD_SCRIPT) .nautilus.o `scripts/findasm.pl`
+	$(LD) $(LDFLAGS) $(LDFLAGS_vmlinux) -o $(BIN_NAME) -T $(LD_SCRIPT) .nautilus.o `scripts/findasm.pl`
 	rm .nautilus.o
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,8 @@ COMMON_FLAGS :=-fno-omit-frame-pointer \
 
 ifdef NAUT_CONFIG_ARCH_RISCV
 
-ifdef NAUT_CONFIG_USE_CLANG
+# we want this for clang and wllvm
+ifndef NAUT_CONFIG_USE_GCC
   COMMON_FLAGS += --target=riscv64 \
                   -mno-relax
 endif

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -7,6 +7,8 @@
 CFLAGS += $(call cc-option,-m64,) 
 AFLAGS += $(call cc-option,-m64,)
 ifndef NAUT_CONFIG_XEON_PHI
+ifdef NAUT_CONFIG_USE_GCC
 LDFLAGS += -melf_x86_64 -dp
+endif
 endif
 

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -163,7 +163,7 @@ cmd_modversions =							\
 		| $(GENKSYMS) -a $(ARCH)				\
 		> $(@D)/.tmp_$(@F:.o=.ver);				\
 									\
-		$(LDCMD) $(LDFLAGS) -r -o $@ $(@D)/.tmp_$(@F) 		\
+		$(LD) $(LDFLAGS) -r -o $@ $(@D)/.tmp_$(@F) 		\
 			-T $(@D)/.tmp_$(@F:.o=.ver);			\
 		rm -f $(@D)/.tmp_$(@F) $(@D)/.tmp_$(@F:.o=.ver);	\
 	else								\
@@ -256,10 +256,10 @@ $(sort $(subdir-obj-y)): $(subdir-ym) ;
 # Rule to compile a set of .o files into one .o file
 #
 ifdef builtin-target
-quiet_cmd_link_o_target = $(LDCMD)      $@
+quiet_cmd_link_o_target = $(LD)      $@
 # If the list of objects to link is empty, just create an empty built-in.o
 cmd_link_o_target = $(if $(strip $(obj-y)),\
-		      $(LDCMD) $(ld_flags) -r -o $@ $(filter $(obj-y), $^),\
+		      $(LD) $(ld_flags) -r -o $@ $(filter $(obj-y), $^),\
 		      rm -f $@; $(AR) rcs $@)
 
 #
@@ -298,11 +298,11 @@ $(filter $(addprefix $(obj)/,         \
 $($(subst $(obj)/,,$(@:.o=-objs)))    \
 $($(subst $(obj)/,,$(@:.o=-y)))), $^)
  
-quiet_cmd_link_multi-y = $(LDCMD)      $@
-cmd_link_multi-y = $(LDCMD) $(ld_flags) -r -o $@ $(link_multi_deps)
+quiet_cmd_link_multi-y = $(LD)      $@
+cmd_link_multi-y = $(LD) $(ld_flags) -r -o $@ $(link_multi_deps)
 
-quiet_cmd_link_multi-m = $(LDCMD) [M]  $@
-cmd_link_multi-m = $(LDCMD) $(ld_flags) $(LDFLAGS_MODULE) -o $@ $(link_multi_deps)
+quiet_cmd_link_multi-m = $(LD) [M]  $@
+cmd_link_multi-m = $(LD) $(ld_flags) $(LDFLAGS_MODULE) -o $@ $(link_multi_deps)
 
 # We would rather have a list of rules like
 # 	foo.o: $(foo-objs)

--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -154,8 +154,8 @@ $(obj)/%:: $(src)/%_shipped
 # Linking
 # ---------------------------------------------------------------------------
 
-quiet_cmd_ld = $(LDCMD)      $@
-cmd_ld = $(LDCMD) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LDFLAGS_$(@F)) \
+quiet_cmd_ld = $(LD)      $@
+cmd_ld = $(LD) $(LDFLAGS) $(EXTRA_LDFLAGS) $(LDFLAGS_$(@F)) \
 	       $(filter-out FORCE,$^) -o $@ 
 
 # Objcopy

--- a/scripts/Makefile.modpost
+++ b/scripts/Makefile.modpost
@@ -84,8 +84,8 @@ $(modules:.ko=.mod.o): %.mod.o: %.mod.c FORCE
 targets += $(modules:.ko=.mod.o)
 
 # Step 6), final link of the modules
-quiet_cmd_ld_ko_o = $(LDCMD) [M]  $@
-      cmd_ld_ko_o = $(LDCMD) $(LDFLAGS) $(LDFLAGS_MODULE) -o $@ 		\
+quiet_cmd_ld_ko_o = $(LD) [M]  $@
+      cmd_ld_ko_o = $(LD) $(LDFLAGS) $(LDFLAGS_MODULE) -o $@ 		\
 			  $(filter-out FORCE,$^)
 
 $(modules): %.ko :%.o %.mod.o FORCE

--- a/user/framework/Makefile
+++ b/user/framework/Makefile
@@ -98,7 +98,7 @@ framework: glue.o framework_low_level.o framework.o
 # 	$(FINALCC) $(CFLAGS) -c $(BLOB_OPT_LL) -o $(BLOB_KOBJ)
 
 # $(BLOB_OBJ) : $(TARGET:.exe=.o) framework.o glue.o
-# 	$(LDCMD) $^ -r -o $(BLOB_OBJ)
+# 	$(LD) $^ -r -o $(BLOB_OBJ)
 
 # $(TARGET:.exe=.unsigned) : $(BLOB_KOBJ) framework_low_level.o
 # 	$(NLD) $^ -o $(TARGET:.exe=.unsigned)


### PR DESCRIPTION
This is a much more clear way to select the correct LD when building with clang than what I did before